### PR TITLE
Adding workspace to cluster object

### DIFF
--- a/nks/clusters.go
+++ b/nks/clusters.go
@@ -33,6 +33,7 @@ type Cluster struct {
 	State                       string             `json:"state,omitempty"`
 	IsFailed                    bool               `json:"is_failed"`
 	ProjectID                   string             `json:"project_id,omitempty"`
+	Workspace                   Workspace          `json:"workspace"`
 	Owner                       int                `json:"owner"`
 	Notified                    bool               `json:"notified,omitempty"`
 	KubernetesVersion           string             `json:"k8s_version"`


### PR DESCRIPTION
We need this in on-prem registration. QM-Rest returns this in the json but we don't pick it up.

If there is a good reason for why this wasn't here in the first place we can work around it, but this is much simpler.